### PR TITLE
Improve handling of empty entries in watch effect

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -609,7 +609,7 @@ const {
 watch(entries, (newItems) => {
   if (!newItems) return;
 
-  if (newItems.length === 0) {
+  if (items.value.length === 0 && newItems.length === 0) {
     if (itemsStatus.value === "unread") {
       if (selectedFeedId.value && selectedCategoryId.value) {
         $q.notify({


### PR DESCRIPTION
Refine the condition for processing empty entries to ensure proper behavior when both current and new items are empty.