### PR TITLE
feat: add health check endpoint for server status monitoring

### DIFF
--- a/server/api/healthz.get.js
+++ b/server/api/healthz.get.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+export default defineEventHandler(async () => {
+  const { container } = useNitroApp();
+
+  /** @type {import('pino').Logger} */
+  const logger = container.resolve("logger");
+  /** @type {Repository} */
+  const repository = container.resolve("repository");
+
+  try {
+    await repository.knex.raw("SELECT 1");
+    return { status: "ok" };
+  } catch (error) {
+    logger.error(error);
+    logger.error("Health check failed");
+    throw createError({ statusCode: 500, statusMessage: "Health check failed" });
+  }
+});


### PR DESCRIPTION
Introduce a health check endpoint to monitor server status, ensuring the application can verify its operational state.

closes #86