### PR TITLE
Fix job pausedAt handling to use null

### DIFF
--- a/server/api/jobs/[name]/toggle.put.js
+++ b/server/api/jobs/[name]/toggle.put.js
@@ -24,8 +24,7 @@ export default defineEventHandler(async (event) => {
   const job = jobs.find((j) => j.name === name);
   if (!job) throw createError({ status: 404, message: "Job not found" });
 
-  const pausedAt = job.pausedAt ? undefined : new Date().toISOString();
-  job.pausedAt = pausedAt;
+  job.pausedAt = job.pausedAt ? null : new Date().toISOString();
   await repository.upsertJob(job);
 
   return job;

--- a/server/utils/entities.js
+++ b/server/utils/entities.js
@@ -119,7 +119,7 @@ export class JobEntity {
    * @param {object} opts
    * @param {number} opts.id
    * @param {string} opts.name
-   * @param {string} [opts.pausedAt]
+   * @param {string|null} [opts.pausedAt]
    * @param {string} [opts.lastDate]
    * @param {number} [opts.lastDurationMs]
    * @param {string} [opts.lastError]

--- a/test/nuxt/repository.test.js
+++ b/test/nuxt/repository.test.js
@@ -869,7 +869,7 @@ describe("Repository", () => {
       assert.strictEqual(jobs[0].pausedAt, pausedAt);
 
       // Unpause a job
-      job.pausedAt = undefined;
+      job.pausedAt = null;
       await repository.upsertJob(job);
 
       jobs = await repository.findJobs();


### PR DESCRIPTION
Update the handling of the `pausedAt` property to use `null` instead of `undefined`, ensuring consistent behavior in job state management. Adjust related type definitions and tests accordingly.